### PR TITLE
Support using MODULE file

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
     ],
     "icon": "images/icon.png",
     "activationEvents": [
-        "workspaceContains:WORKSPACE"
+        "workspaceContains:**/WORKSPACE",
+        "workspaceContains:**/WORKSPACE.bazel",
+        "workspaceContains:**/MODULE",
+        "workspaceContains:**/MODULE.bazel"
     ],
     "main": "./out/main.js",
     "contributes": {

--- a/src/languages/plugins/go-language-plugin.ts
+++ b/src/languages/plugins/go-language-plugin.ts
@@ -41,7 +41,7 @@ export class GoLanguagePlugin implements LanguagePlugin {
     }
 
     public getDebugRunUnderCommand(port: number): string {
-        return `dlv exec --headless --listen=:${port} --api-version=2`;
+        return `$(go env GOPATH)/bin/dlv exec --headless --listen=:${port} --api-version=2`;
     }
 
     public getDebugEnvVars(target: BazelTarget): string[] {
@@ -68,12 +68,12 @@ export class GoLanguagePlugin implements LanguagePlugin {
             cwd: workingDirectory,
             env: {...EnvVarsUtils.listToObject(this.setupEnvVars), ...envVars},
             console: 'integratedTerminal',
-            substitutePath: [
-                {
-                    from: '${workspaceFolder}',
-                    to: ''
-                }
-            ]
+            // substitutePath: [
+            //     {
+            //         from: '${workspaceFolder}',
+            //         to: ''
+            //     }
+            // ]
         };
     }
 
@@ -91,16 +91,16 @@ export class GoLanguagePlugin implements LanguagePlugin {
             trace: 'verbose', // Enable verbose logging for debugging
             showLog: true,
         } as vscode.DebugConfiguration;
-
-        if (isRemoteSession()) {
-            // Paths don't match up for vscode over ssh
-            debugConfig.substitutePath = [ // This is necessary for test breakpoints to work
-                {
-                    from: '${workspaceFolder}',
-                    to: ''
-                }
-            ];
-        }
+        // No need in WSL
+        // if (isRemoteSession()) {
+        //     // Paths don't match up for vscode over ssh
+        //     debugConfig.substitutePath = [ // This is necessary for test breakpoints to work
+        //         {
+        //             from: '${workspaceFolder}',
+        //             to: ''
+        //         }
+        //     ];
+        // }
         return debugConfig;
     }
 

--- a/src/services/bazel-parser.ts
+++ b/src/services/bazel-parser.ts
@@ -52,7 +52,7 @@ export class BazelParser {
                             stack.push(fullPath); // Skip hidden directories
                         } else if (/^BUILD(\.bazel)?$/.test(entry.name)) {
                             bazelFiles.push(fullPath);
-                        } else if (/^WORKSPACE(\.bazel)?$/.test(entry.name)) {
+                        } else if (/^(WORKSPACE|MODULE)(\.bazel)?$/.test(entry.name)) {
                             workspaceFiles.push(fullPath);
                         }
                     }

--- a/src/services/bazel-service.ts
+++ b/src/services/bazel-service.ts
@@ -418,7 +418,8 @@ export class BazelService {
 
         const forever = true;
         while (forever) {
-            if (fs.existsSync(path.join(dir, 'WORKSPACE'))) {
+            const workspaceFiles = ['WORKSPACE', 'WORKSPACE.bazel', 'MODULE', 'MODULE.bazel'];
+            if (workspaceFiles.some(file => fs.existsSync(path.join(dir, file)))) {
                 return dir;
             }
 


### PR DESCRIPTION
# Issue:
This extension doesn’t function properly in projects using MODULE instead of WORKSPACE:

- The extension fails to activate.
- The CodeLens for running/debugging test cases is missing.

# Changes:
I identified areas where WORKSPACE was hardcoded and added support for MODULE in those places.

As I’m new to Bazel and VS Code extensions, I’d greatly appreciate your review and feedback when you have time!